### PR TITLE
Add missing 'GitHub Skills' activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -33,6 +33,12 @@ activities = {
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Hands-on coding and collaboration workshops with GitHub — learn git, pull requests, and GitHub features.",
+        "schedule": "Saturdays, 10:00 AM - 12:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",


### PR DESCRIPTION
This PR adds the missing "GitHub Skills" activity to the in-memory activities list so that the activity is visible on the site (addresses Issue #6 — Missing Activity). It is a small, low-risk change: a new activity entry in `src/app.py`.

If you'd like, I can also extract the activities into `activities.json` in a follow-up PR for easier maintenance.